### PR TITLE
utils: Guard LoadLibrary against dll preloading / hijacking attacks

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8,13 +8,16 @@
 
 typedef HRESULT (WINAPI *PGetDpiForMonitor)(HMONITOR hmonitor, int dpiType, UINT* dpiX, UINT* dpiY);
 
+#ifndef LOAD_LIBRARY_SEARCH_SYSTEM32
+#define LOAD_LIBRARY_SEARCH_SYSTEM32            0x00000800
+#endif
 
 WORD
 GetWindowDPI(HWND hWnd)
 {
     // Try to get the DPI setting for the monitor where the given window is located.
     // This API is Windows 8.1+.
-    HMODULE hShcore = LoadLibraryW(L"shcore");
+    HMODULE hShcore = SafeLoadSystemLibrary(L"shcore.dll");
     if (hShcore)
     {
         PGetDpiForMonitor pGetDpiForMonitor = reinterpret_cast<PGetDpiForMonitor>(GetProcAddress(hShcore, "GetDpiForMonitor"));
@@ -98,4 +101,37 @@ LoadPNGAsGdiplusBitmap(HINSTANCE hInstance, UINT uID)
     }
 
     return pBitmap;
+}
+
+HMODULE
+SafeLoadSystemLibrary(const std::wstring& LibraryName)
+{
+    // LOAD_LIBRARY_SEARCH_SYSTEM32 is only supported if KB2533623 is installed on Vista / Win7, and starting from Win8
+    FARPROC pSetDefaultDllDirectories = ::GetProcAddress(::GetModuleHandleW(L"kernel32.dll"), "SetDefaultDllDirectories");
+    if (pSetDefaultDllDirectories)
+    {
+        return ::LoadLibraryExW(LibraryName.c_str(), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+    }
+
+    // We have to do this manually, so first ask how big our buffer needs to be (including null terminator)
+    UINT len = GetSystemDirectoryW(NULL, 0);
+    std::wstring FullPath(len, L'\0');
+
+    // Now fill the buffer, and query the result (excluding null terminator!)
+    len = ::GetSystemDirectoryW(FullPath.data(), FullPath.size());
+    if (len == 0 || len >= FullPath.size())
+    {
+        return NULL;
+    }
+
+    // Clean up the null terminator
+    FullPath.resize(len);
+
+    // Ensure our path ends with a slash
+    if (FullPath[len-1] != L'\\' && FullPath[len-1] != L'/')
+        FullPath += L'\\';
+
+    FullPath += LibraryName;
+
+    return ::LoadLibraryExW(FullPath.data(), NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -34,3 +34,4 @@ InstanceFromWndProc(HWND hWnd, UINT uMsg, LPARAM lParam)
 WORD GetWindowDPI(HWND hWnd);
 std::wstring LoadStringAsWstr(HINSTANCE hInstance, UINT uID);
 std::unique_ptr<Gdiplus::Bitmap> LoadPNGAsGdiplusBitmap(HINSTANCE hInstance, UINT uID);
+HMODULE SafeLoadSystemLibrary(const std::wstring& LibraryName);


### PR DESCRIPTION
See https://support.microsoft.com/en-us/help/2389418/secure-loading-of-libraries-to-prevent-dll-preloading-attacks for more info
