### PR TITLE
Fix drawing artifacts when resizing a page with multiple controls

### DIFF
--- a/src/CMainWindow.cpp
+++ b/src/CMainWindow.cpp
@@ -321,6 +321,7 @@ CMainWindow::Create(HINSTANCE hInstance, int nShowCmd)
     wc.hInstance = hInstance;
     wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
     wc.hIcon = LoadIconW(hInstance, MAKEINTRESOURCEW(IDI_ICON));
+    wc.hbrBackground = GetSysColorBrush(COLOR_BTNFACE);
     wc.lpszClassName = CMainWindow::_wszWndClass;
 
     if (RegisterClassW(&wc) == 0)

--- a/src/CPage.h
+++ b/src/CPage.h
@@ -27,6 +27,7 @@ protected:
         wc.lpfnWndProc = T::_WndProc;
         wc.hInstance = pMainWindow->GetHInstance();
         wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+        wc.hbrBackground = GetSysColorBrush(COLOR_BTNFACE);
         wc.lpszClassName = T::_wszWndClass;
         if (RegisterClassW(&wc) == 0)
         {


### PR DESCRIPTION
When using multiple controls on a page (so not like the 2 example pages, which draw both 1 thing), there are resizing artifacts.
Setting a background brush fixes this.