### PR TITLE
Fix DeferWindowPos usage

### DIFF
--- a/src/CMainWindow.cpp
+++ b/src/CMainWindow.cpp
@@ -269,43 +269,65 @@ CMainWindow::_OnSize()
 
     // Move the buttons.
     HDWP hDwp = BeginDeferWindowPos(7);
+    if (!hDwp)
+    {
+        return 0;
+    }
 
     const int iControlPadding = MulDiv(10, m_wCurrentDPI, iWindowsReferenceDPI);
     int iButtonHeight = MulDiv(23, m_wCurrentDPI, iWindowsReferenceDPI);
     int iButtonWidth = MulDiv(90, m_wCurrentDPI, iWindowsReferenceDPI);
     int iButtonX = rcWindow.right - iControlPadding - iButtonWidth;
     int iButtonY = rcWindow.bottom - iControlPadding - iButtonHeight;
-    if (hDwp)
-        hDwp = DeferWindowPos(hDwp, m_hCancel, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
+    hDwp = DeferWindowPos(hDwp, m_hCancel, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
+    if (!hDwp)
+    {
+        return 0;
+    }
 
     iButtonX = iButtonX - iControlPadding - iButtonWidth;
-    if (hDwp)
-        hDwp = DeferWindowPos(hDwp, m_hNext, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
+    hDwp = DeferWindowPos(hDwp, m_hNext, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
+    if (!hDwp)
+    {
+        return 0;
+    }
 
     iButtonX = iButtonX - iButtonWidth;
-    if (hDwp)
-        hDwp = DeferWindowPos(hDwp, m_hBack, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
+    hDwp = DeferWindowPos(hDwp, m_hBack, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
+    if (!hDwp)
+    {
+        return 0;
+    }
 
     // Move the line above the buttons.
     int iLineHeight = 2;
     int iLineWidth = rcWindow.right;
     int iLineX = 0;
     int iLineY = iButtonY - iControlPadding;
-    if (hDwp)
-        hDwp = DeferWindowPos(hDwp, m_hLine, nullptr, iLineX, iLineY, iLineWidth, iLineHeight, 0);
+    hDwp = DeferWindowPos(hDwp, m_hLine, nullptr, iLineX, iLineY, iLineWidth, iLineHeight, 0);
+    if (!hDwp)
+    {
+        return 0;
+    }
 
     // Move all page windows.
     int iPageX = iControlPadding;
     int iPageY = rcHeader.bottom + iControlPadding;
     int iPageHeight = iLineY - iPageY - iControlPadding;
     int iPageWidth = rcWindow.right - iPageX - iControlPadding;
-    if (hDwp)
-        hDwp = DeferWindowPos(hDwp, m_pFirstPage->GetHwnd(), nullptr, iPageX, iPageY, iPageWidth, iPageHeight, 0);
-    if (hDwp)
-        hDwp = DeferWindowPos(hDwp, m_pSecondPage->GetHwnd(), nullptr, iPageX, iPageY, iPageWidth, iPageHeight, 0);
+    hDwp = DeferWindowPos(hDwp, m_pFirstPage->GetHwnd(), nullptr, iPageX, iPageY, iPageWidth, iPageHeight, 0);
+    if (!hDwp)
+    {
+        return 0;
+    }
+    
+    hDwp = DeferWindowPos(hDwp, m_pSecondPage->GetHwnd(), nullptr, iPageX, iPageY, iPageWidth, iPageHeight, 0);
+    if (!hDwp)
+    {
+        return 0;
+    }
 
-    if (hDwp)
-        EndDeferWindowPos(hDwp);
+    EndDeferWindowPos(hDwp);
 
     return 0;
 }

--- a/src/CMainWindow.cpp
+++ b/src/CMainWindow.cpp
@@ -275,30 +275,37 @@ CMainWindow::_OnSize()
     int iButtonWidth = MulDiv(90, m_wCurrentDPI, iWindowsReferenceDPI);
     int iButtonX = rcWindow.right - iControlPadding - iButtonWidth;
     int iButtonY = rcWindow.bottom - iControlPadding - iButtonHeight;
-    DeferWindowPos(hDwp, m_hCancel, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
+    if (hDwp)
+        hDwp = DeferWindowPos(hDwp, m_hCancel, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
 
     iButtonX = iButtonX - iControlPadding - iButtonWidth;
-    DeferWindowPos(hDwp, m_hNext, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
+    if (hDwp)
+        hDwp = DeferWindowPos(hDwp, m_hNext, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
 
     iButtonX = iButtonX - iButtonWidth;
-    DeferWindowPos(hDwp, m_hBack, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
+    if (hDwp)
+        hDwp = DeferWindowPos(hDwp, m_hBack, nullptr, iButtonX, iButtonY, iButtonWidth, iButtonHeight, 0);
 
     // Move the line above the buttons.
     int iLineHeight = 2;
     int iLineWidth = rcWindow.right;
     int iLineX = 0;
     int iLineY = iButtonY - iControlPadding;
-    DeferWindowPos(hDwp, m_hLine, nullptr, iLineX, iLineY, iLineWidth, iLineHeight, 0);
+    if (hDwp)
+        hDwp = DeferWindowPos(hDwp, m_hLine, nullptr, iLineX, iLineY, iLineWidth, iLineHeight, 0);
 
     // Move all page windows.
     int iPageX = iControlPadding;
     int iPageY = rcHeader.bottom + iControlPadding;
     int iPageHeight = iLineY - iPageY - iControlPadding;
     int iPageWidth = rcWindow.right - iPageX - iControlPadding;
-    DeferWindowPos(hDwp, m_pFirstPage->GetHwnd(), nullptr, iPageX, iPageY, iPageWidth, iPageHeight, 0);
-    DeferWindowPos(hDwp, m_pSecondPage->GetHwnd(), nullptr, iPageX, iPageY, iPageWidth, iPageHeight, 0);
+    if (hDwp)
+        hDwp = DeferWindowPos(hDwp, m_pFirstPage->GetHwnd(), nullptr, iPageX, iPageY, iPageWidth, iPageHeight, 0);
+    if (hDwp)
+        hDwp = DeferWindowPos(hDwp, m_pSecondPage->GetHwnd(), nullptr, iPageX, iPageY, iPageWidth, iPageHeight, 0);
 
-    EndDeferWindowPos(hDwp);
+    if (hDwp)
+        EndDeferWindowPos(hDwp);
 
     return 0;
 }

--- a/src/CSecondPage.cpp
+++ b/src/CSecondPage.cpp
@@ -46,9 +46,11 @@ CSecondPage::_OnSize()
     int iListY = 0;
     int iListHeight = rcWindow.bottom;
     int iListWidth = rcWindow.right;
-    DeferWindowPos(hDwp, m_hList, nullptr, iListX, iListY, iListWidth, iListHeight, 0);
+    if (hDwp)
+        hDwp = DeferWindowPos(hDwp, m_hList, nullptr, iListX, iListY, iListWidth, iListHeight, 0);
 
-    EndDeferWindowPos(hDwp);
+    if (hDwp)
+        EndDeferWindowPos(hDwp);
 
     // Adjust the list column widths.
     LONG lColumnWidth = rcWindow.right / 3;

--- a/src/CSecondPage.cpp
+++ b/src/CSecondPage.cpp
@@ -41,16 +41,22 @@ CSecondPage::_OnSize()
 
     // Move the list control.
     HDWP hDwp = BeginDeferWindowPos(1);
+    if (!hDwp)
+    {
+        return 0;
+    }
 
     int iListX = 0;
     int iListY = 0;
     int iListHeight = rcWindow.bottom;
     int iListWidth = rcWindow.right;
-    if (hDwp)
-        hDwp = DeferWindowPos(hDwp, m_hList, nullptr, iListX, iListY, iListWidth, iListHeight, 0);
+    hDwp = DeferWindowPos(hDwp, m_hList, nullptr, iListX, iListY, iListWidth, iListHeight, 0);
+    if (!hDwp)
+    {
+        return 0;
+    }
 
-    if (hDwp)
-        EndDeferWindowPos(hDwp);
+    EndDeferWindowPos(hDwp);
 
     // Adjust the list column widths.
     LONG lColumnWidth = rcWindow.right / 3;


### PR DESCRIPTION
As explained on msdn:
> The return value identifies the updated multiple-window – position structure. The handle returned by this function may differ from the handle passed to the function. The new handle that this function returns should be passed during the next call to the DeferWindowPos or EndDeferWindowPos function.

And:
> If a call to DeferWindowPos fails, the application should abandon the window-positioning operation and not call EndDeferWindowPos.

https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-deferwindowpos