### PR TITLE
Add wildcard in manifest string, so that it can be used for x64

### DIFF
--- a/src/Wizard-2020.h
+++ b/src/Wizard-2020.h
@@ -7,7 +7,7 @@
 #pragma once
 
 // Enable Visual Styles
-#pragma comment(linker, "/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='x86' publicKeyToken='6595b64144ccf1df' language='*'\"")
+#pragma comment(linker, "/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
 
 #include <string>
 


### PR DESCRIPTION
Without this, the x64 build of the project fails to start because it cannot load the 32bit dll.